### PR TITLE
Update release script to point to new dir structure

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -10,7 +10,7 @@ git fetch
 git checkout "$1"
 cd ..
 rm -rf ProjectDescription
-cp -r tuist/Sources/ProjectDescription .
+cp -r tuist/cli/Sources/ProjectDescription .
 git add ProjectDescription/**
 git commit -am "$1" --allow-empty
 git push


### PR DESCRIPTION
I wanted to sync the ProjectDescription repo to be up to date with Tuist main, but realized that the script points to a directory that doesn't exist in the monorepo. 
